### PR TITLE
Add !default flag for variables

### DIFF
--- a/scss/components/_off-canvas.scss
+++ b/scss/components/_off-canvas.scss
@@ -8,34 +8,34 @@
 
 /// Width of an off-canvas menu.
 /// @type Number
-$offcanvas-size: 250px;
+$offcanvas-size: 250px !default;
 
 /// Background color of an off-canvas menu.
 /// @type Color
-$offcanvas-background: $light-gray;
+$offcanvas-background: $light-gray !default;
 
 /// Z-index of an off-canvas menu.
 /// @type Number
-$offcanvas-zindex: -1;
+$offcanvas-zindex: -1 !default;
 
 /// Length of the animation on an off-canvas menu.
 /// @type Number
-$offcanvas-transition-length: 0.5s;
+$offcanvas-transition-length: 0.5s !default;
 
 /// Timing function of the animation on an off-canvas menu.
 /// @type Keyword
-$offcanvas-transition-timing: ease;
+$offcanvas-transition-timing: ease !default;
 
 /// Background color for the overlay that appears when an off-canvas menu is open.
 /// @type Color
-$offcanvas-exit-background: rgba($white, 0.25);
+$offcanvas-exit-background: rgba($white, 0.25) !default;
 
 /// CSS class used for the main content area. The off-canvas mixins use this to target the page body.
-$maincontent-class: 'off-canvas-content';
+$maincontent-class: 'off-canvas-content' !default;
 
 /// Box shadow to place under the main content area. This shadow overlaps the off-canvas menus.
 /// @type Shadow
-$maincontent-shadow: 0 0 10px rgba($black, 0.5);
+$maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
 
 /// Adds baseline styles for off-canvas. This CSS is required to make the other pieces work.
 @mixin off-canvas-basics {


### PR DESCRIPTION
The variables for the off-canvas menu were not being overridden via the _settings file. I added the !default flag to each variable which seems to have solved the problem.
